### PR TITLE
Add new bool to block_place

### DIFF
--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -3791,6 +3791,7 @@
       cursorY: f32
       cursorZ: f32
       insideBlock: bool
+      worldBorderHit: bool
       sequence: varint
    # MC: ServerboundUseItemPacket
    packet_use_item:


### PR DESCRIPTION
Seems to be a new boolean added to the block_place packet, could not find any info on wiki.vg...

Here is where I found it:
https://github.com/extremeheat/extracted_minecraft_data/blob/5039f20f44683c70125a85e62880c2e78798228e/client/net/minecraft/network/FriendlyByteBuf.java#L687

This is my first time contributing to mineflayer so I don't know if I'm doing it right, but this worked on my local install. I won't upload the compiled protocol.json incase you guys want to make any changes first. 

Thanks!