### PR TITLE
Complete outstanding tasks for 1.21.3 update

### DIFF
--- a/data/pc/1.21.3/protocol.json
+++ b/data/pc/1.21.3/protocol.json
@@ -5780,8 +5780,8 @@
               "type": "varint"
             },
             {
-              "name": "data",
-              "type": "void"
+              "name": "recipeDisplay",
+              "type": "SlotDisplay"
             }
           ]
         ],
@@ -6146,21 +6146,59 @@
           ]
         ],
         "PositionUpdateRelatives": [
-          "bitflags",
-          {
-            "type": "u32",
-            "flags": [
-              "x",
-              "y",
-              "z",
-              "yaw",
-              "pitch",
-              "dx",
-              "dy",
-              "dz",
-              "yawDelta"
-            ]
-          }
+          "bitfield",
+          [
+            {
+              "name": "unused",
+              "size": 23,
+              "signed": false
+            },
+            {
+              "name": "yawDelta",
+              "size": 1,
+              "signed": false
+            },
+            {
+              "name": "dz",
+              "size": 1,
+              "signed": false
+            },
+            {
+              "name": "dy",
+              "size": 1,
+              "signed": false
+            },
+            {
+              "name": "dx",
+              "size": 1,
+              "signed": false
+            },
+            {
+              "name": "pitch",
+              "size": 1,
+              "signed": false
+            },
+            {
+              "name": "yaw",
+              "size": 1,
+              "signed": false
+            },
+            {
+              "name": "z",
+              "size": 1,
+              "signed": false
+            },
+            {
+              "name": "y",
+              "size": 1,
+              "signed": false
+            },
+            {
+              "name": "x",
+              "size": 1,
+              "signed": false
+            }
+          ]
         ],
         "packet_position": [
           "container",
@@ -6233,239 +6271,242 @@
                     "container",
                     [
                       {
-                        "name": "contents",
+                        "name": "recipeId",
+                        "type": "varint"
+                      },
+                      {
+                        "name": "display",
                         "type": [
                           "container",
                           [
                             {
-                              "name": "displayId",
-                              "type": "varint"
-                            },
-                            {
-                              "name": "display",
-                              "type": [
-                                "container",
-                                [
-                                  {
-                                    "name": "type",
-                                    "type": [
-                                      "mapper",
-                                      {
-                                        "type": "varint",
-                                        "mappings": {
-                                          "0": "crafting_shapeless",
-                                          "1": "crafting_shaped",
-                                          "2": "furnace",
-                                          "3": "stonecutter",
-                                          "4": "smithing"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "name": "data",
-                                    "type": [
-                                      "switch",
-                                      {
-                                        "compareTo": "type",
-                                        "fields": {
-                                          "crafting_shapeless": [
-                                            "container",
-                                            [
-                                              {
-                                                "name": "ingredients",
-                                                "type": [
-                                                  "array",
-                                                  {
-                                                    "countType": "varint",
-                                                    "type": "SlotDisplay"
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "name": "result",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "craftingStation",
-                                                "type": "SlotDisplay"
-                                              }
-                                            ]
-                                          ],
-                                          "crafting_shaped": [
-                                            "container",
-                                            [
-                                              {
-                                                "name": "width",
-                                                "type": "varint"
-                                              },
-                                              {
-                                                "name": "height",
-                                                "type": "varint"
-                                              },
-                                              {
-                                                "name": "ingredients",
-                                                "type": [
-                                                  "array",
-                                                  {
-                                                    "countType": "varint",
-                                                    "type": "SlotDisplay"
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "name": "result",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "craftingStation",
-                                                "type": "SlotDisplay"
-                                              }
-                                            ]
-                                          ],
-                                          "furnace": [
-                                            "container",
-                                            [
-                                              {
-                                                "name": "ingredient",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "fuel",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "result",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "craftingStation",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "duration",
-                                                "type": "varint"
-                                              },
-                                              {
-                                                "name": "experience",
-                                                "type": "f32"
-                                              }
-                                            ]
-                                          ],
-                                          "stonecutter": [
-                                            "container",
-                                            [
-                                              {
-                                                "name": "ingredient",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "result",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "craftingStation",
-                                                "type": "SlotDisplay"
-                                              }
-                                            ]
-                                          ],
-                                          "smithing": [
-                                            "container",
-                                            [
-                                              {
-                                                "name": "template",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "base",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "addition",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "result",
-                                                "type": "SlotDisplay"
-                                              },
-                                              {
-                                                "name": "craftingStation",
-                                                "type": "SlotDisplay"
-                                              }
-                                            ]
-                                          ]
-                                        }
-                                      }
-                                    ]
-                                  }
-                                ]
-                              ]
-                            },
-                            {
-                              "name": "group",
-                              "type": [
-                                "option",
-                                "varint"
-                              ]
-                            },
-                            {
-                              "name": "category",
+                              "name": "type",
                               "type": [
                                 "mapper",
                                 {
                                   "type": "varint",
                                   "mappings": {
-                                    "0": "crafting_building_blocks",
-                                    "1": "crafting_redstone",
-                                    "2": "crafting_equipment",
-                                    "3": "crafting_misc",
-                                    "4": "furnace_food",
-                                    "5": "furnace_blocks",
-                                    "6": "furnace_misc",
-                                    "7": "blast_furnace_blocks",
-                                    "8": "blast_furnace_misc",
-                                    "9": "smoker_food",
-                                    "10": "stonecutter",
-                                    "11": "smithing",
-                                    "12": "campfire"
+                                    "0": "crafting_shapeless",
+                                    "1": "crafting_shaped",
+                                    "2": "furnace",
+                                    "3": "stonecutter",
+                                    "4": "smithing"
                                   }
                                 }
                               ]
                             },
                             {
-                              "name": "craftingRequirements",
+                              "name": "data",
                               "type": [
-                                "option",
-                                [
-                                  "registryEntryHolderSet",
-                                  {
-                                    "base": {
-                                      "name": "name",
-                                      "type": "string"
-                                    },
-                                    "otherwise": {
-                                      "name": "ids",
-                                      "type": "varint"
-                                    }
+                                "switch",
+                                {
+                                  "compareTo": "type",
+                                  "fields": {
+                                    "crafting_shapeless": [
+                                      "container",
+                                      [
+                                        {
+                                          "name": "ingredients",
+                                          "type": [
+                                            "array",
+                                            {
+                                              "countType": "varint",
+                                              "type": "SlotDisplay"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "name": "result",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "craftingStation",
+                                          "type": "SlotDisplay"
+                                        }
+                                      ]
+                                    ],
+                                    "crafting_shaped": [
+                                      "container",
+                                      [
+                                        {
+                                          "name": "width",
+                                          "type": "varint"
+                                        },
+                                        {
+                                          "name": "height",
+                                          "type": "varint"
+                                        },
+                                        {
+                                          "name": "ingredients",
+                                          "type": [
+                                            "array",
+                                            {
+                                              "countType": "varint",
+                                              "type": "SlotDisplay"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "name": "result",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "craftingStation",
+                                          "type": "SlotDisplay"
+                                        }
+                                      ]
+                                    ],
+                                    "furnace": [
+                                      "container",
+                                      [
+                                        {
+                                          "name": "ingredient",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "fuel",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "result",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "craftingStation",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "duration",
+                                          "type": "varint"
+                                        },
+                                        {
+                                          "name": "experience",
+                                          "type": "f32"
+                                        }
+                                      ]
+                                    ],
+                                    "stonecutter": [
+                                      "container",
+                                      [
+                                        {
+                                          "name": "ingredient",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "result",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "craftingStation",
+                                          "type": "SlotDisplay"
+                                        }
+                                      ]
+                                    ],
+                                    "smithing": [
+                                      "container",
+                                      [
+                                        {
+                                          "name": "template",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "base",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "addition",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "result",
+                                          "type": "SlotDisplay"
+                                        },
+                                        {
+                                          "name": "craftingStation",
+                                          "type": "SlotDisplay"
+                                        }
+                                      ]
+                                    ]
                                   }
-                                ]
+                                }
                               ]
                             }
                           ]
                         ]
                       },
                       {
-                        "name": "flags",
+                        "name": "groupId",
+                        "type": "varint"
+                      },
+                      {
+                        "name": "categoryId",
                         "type": [
-                          "bitflags",
+                          "mapper",
                           {
-                            "type": "u8",
-                            "flags": [
-                              "notification",
-                              "highlight"
-                            ]
+                            "type": "varint",
+                            "mappings": {
+                              "0": "crafting_building_blocks",
+                              "1": "crafting_redstone",
+                              "2": "crafting_equipment",
+                              "3": "crafting_misc",
+                              "4": "furnace_food",
+                              "5": "furnace_blocks",
+                              "6": "furnace_misc",
+                              "7": "blast_furnace_blocks",
+                              "8": "blast_furnace_misc",
+                              "9": "smoker_food",
+                              "10": "stonecutter",
+                              "11": "smithing",
+                              "12": "campfire"
+                            }
                           }
                         ]
+                      },
+                      {
+                        "name": "hasIngredients",
+                        "type": "bool"
+                      },
+                      {
+                        "name": "ingredientCount",
+                        "type": [
+                          "switch",
+                          {
+                            "compareTo": "hasIngredients",
+                            "fields": {
+                              "true": "varint"
+                            },
+                            "default": "void"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "ingredients",
+                        "type": [
+                          "switch",
+                          {
+                            "compareTo": "hasIngredients",
+                            "fields": {
+                              "true": [
+                                "registryEntryHolderSet",
+                                {
+                                  "base": {
+                                    "name": "name",
+                                    "type": "string"
+                                  },
+                                  "otherwise": {
+                                    "name": "ids",
+                                    "type": "varint"
+                                  }
+                                }
+                              ]
+                            },
+                            "default": "void"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "flags",
+                        "type": "u8"
                       }
                     ]
                   ]
@@ -7881,7 +7922,11 @@
           "container",
           [
             {
-              "name": "recipes",
+              "name": "propertySetCount",
+              "type": "varint"
+            },
+            {
+              "name": "propertySets",
               "type": [
                 "array",
                 {
@@ -7890,8 +7935,12 @@
                     "container",
                     [
                       {
-                        "name": "name",
+                        "name": "propertySetId",
                         "type": "string"
+                      },
+                      {
+                        "name": "itemCount",
+                        "type": "varint"
                       },
                       {
                         "name": "items",
@@ -7909,7 +7958,11 @@
               ]
             },
             {
-              "name": "stoneCutterRecipes",
+              "name": "stonecutterRecipeCount",
+              "type": "varint"
+            },
+            {
+              "name": "stonecutterRecipes",
               "type": [
                 "array",
                 {
@@ -7918,7 +7971,7 @@
                     "container",
                     [
                       {
-                        "name": "input",
+                        "name": "ingredients",
                         "type": [
                           "registryEntryHolderSet",
                           {
@@ -8806,14 +8859,24 @@
           ]
         ],
         "MovementFlags": [
-          "bitflags",
-          {
-            "type": "u8",
-            "flags": [
-              "onGround",
-              "hasHorizontalCollision"
-            ]
-          }
+          "bitfield",
+          [
+            {
+              "name": "onGround",
+              "size": 1,
+              "signed": false
+            },
+            {
+              "name": "hasHorizontalCollision",
+              "size": 1,
+              "signed": false
+            },
+            {
+              "name": "unused",
+              "size": 6,
+              "signed": false
+            }
+          ]
         ],
         "packet_position": [
           "container",
@@ -9017,19 +9080,49 @@
             {
               "name": "inputs",
               "type": [
-                "bitflags",
-                {
-                  "type": "u8",
-                  "flags": [
-                    "forward",
-                    "backward",
-                    "left",
-                    "right",
-                    "jump",
-                    "sneak",
-                    "sprint"
-                  ]
-                }
+                "bitfield",
+                [
+                  {
+                    "name": "forward",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "backward",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "left",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "right",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "jump",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "shift",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "sprint",
+                    "size": 1,
+                    "signed": false
+                  },
+                  {
+                    "name": "unused",
+                    "size": 1,
+                    "signed": false
+                  }
+                ]
               ]
             }
           ]

--- a/data/pc/latest/proto.yml
+++ b/data/pc/latest/proto.yml
@@ -2027,7 +2027,7 @@
    packet_craft_recipe_response:
       windowId: ContainerID
       recipeDisplayId: varint
-      data: void # TODO
+      recipeDisplay: SlotDisplay
    # MC: ClientboundPlayerAbilitiesPacket
    packet_abilities:
       flags: i8
@@ -2120,23 +2120,24 @@
          default: void
 
    # https://github.com/extremeheat/extracted_minecraft_data/blob/client1.21.2/client/net/minecraft/world/entity/Relative.java#L82
-   PositionUpdateRelatives: ["bitflags", {
-      "type": "u32",
-      "flags": ["x", "y", "z", "yaw", "pitch", "dx", "dy", "dz", "yawDelta"]
-   }]
-   # PositionUpdateRelatives: ["bitfield", [
-   #    # unused bits on top
-   #    { "name": "unused", "size": 23, "signed": false },
-   #    { "name": "yawDelta", "size": 1, "signed": false },
-   #    { "name": "dz", "size": 1, "signed": false },
-   #    { "name": "dy", "size": 1, "signed": false },
-   #    { "name": "dx", "size": 1, "signed": false },
-   #    { "name": "pitch", "size": 1, "signed": false },
-   #    { "name": "yaw", "size": 1, "signed": false },
-   #    { "name": "z", "size": 1, "signed": false },
-   #    { "name": "y", "size": 1, "signed": false },
-   #    { "name": "x", "size": 1, "signed": false },
-   # ]]
+   # PositionUpdateRelatives: ["bitflags", {
+   #    "type": "u32",
+   #    "flags": ["x", "y", "z", "yaw", "pitch", "dx", "dy", "dz", "yawDelta"]
+   # }]
+   PositionUpdateRelatives: ["bitfield", [
+      # unused bits on top
+      { "name": "unused", "size": 23, "signed": false },
+      { "name": "yawDelta", "size": 1, "signed": false },
+      { "name": "dz", "size": 1, "signed": false },
+      { "name": "dy", "size": 1, "signed": false },
+      { "name": "dx", "size": 1, "signed": false },
+      { "name": "pitch", "size": 1, "signed": false },
+      { "name": "yaw", "size": 1, "signed": false },
+      { "name": "z", "size": 1, "signed": false },
+      { "name": "y", "size": 1, "signed": false },
+      { "name": "x", "size": 1, "signed": false },
+   ]]
+
    # MC: ClientboundPlayerPositionPacket
    packet_position:
       teleportId: varint
@@ -2155,71 +2156,70 @@
       pitch: f32
 
    # MC: ClientboundRecipeBookAddPacket
-   # TODO
    packet_recipe_book_add:
       entries: []varint
-         # RecipeDisplayEntry
-         contents:
-            displayId: varint
-            display:
-               type: varint =>
-               - crafting_shapeless
-               - crafting_shaped
-               - furnace
-               - stonecutter
-               - smithing
-               data: type ?
-                  if crafting_shapeless:
-                     ingredients: SlotDisplay[]varint
-                     result: SlotDisplay
-                     craftingStation: SlotDisplay
-                  if crafting_shaped:
-                     width: varint
-                     height: varint
-                     ingredients: SlotDisplay[]varint
-                     result: SlotDisplay
-                     craftingStation: SlotDisplay
-                  if furnace:
-                     ingredient: SlotDisplay
-                     fuel: SlotDisplay
-                     result: SlotDisplay
-                     craftingStation: SlotDisplay
-                     duration: varint
-                     experience: f32
-                  if stonecutter:
-                     ingredient: SlotDisplay
-                     result: SlotDisplay
-                     craftingStation: SlotDisplay
-                  if smithing:
-                     template: SlotDisplay
-                     base: SlotDisplay
-                     addition: SlotDisplay
-                     result: SlotDisplay
-                     craftingStation: SlotDisplay
-            group?: varint
-            # This ID corresponds to the "recipe_book_category" registry
-            category: varint =>
-            - crafting_building_blocks
-            - crafting_redstone
-            - crafting_equipment
-            - crafting_misc
-            - furnace_food
-            - furnace_blocks
-            - furnace_misc
-            - blast_furnace_blocks
-            - blast_furnace_misc
-            - smoker_food
+         recipeId: varint
+         display:
+            type: varint =>
+            - crafting_shapeless
+            - crafting_shaped
+            - furnace
             - stonecutter
             - smithing
-            - campfire
-            craftingRequirements?: ["registryEntryHolderSet", {
+            data: type ?
+               if crafting_shapeless:
+                  ingredients: SlotDisplay[]varint
+                  result: SlotDisplay
+                  craftingStation: SlotDisplay
+               if crafting_shaped:
+                  width: varint
+                  height: varint
+                  ingredients: SlotDisplay[]varint
+                  result: SlotDisplay
+                  craftingStation: SlotDisplay
+               if furnace:
+                  ingredient: SlotDisplay
+                  fuel: SlotDisplay
+                  result: SlotDisplay
+                  craftingStation: SlotDisplay
+                  duration: varint
+                  experience: f32
+               if stonecutter:
+                  ingredient: SlotDisplay
+                  result: SlotDisplay
+                  craftingStation: SlotDisplay
+               if smithing:
+                  template: SlotDisplay
+                  base: SlotDisplay
+                  addition: SlotDisplay
+                  result: SlotDisplay
+                  craftingStation: SlotDisplay
+         groupId: varint
+         categoryId: varint =>
+         - crafting_building_blocks
+         - crafting_redstone
+         - crafting_equipment
+         - crafting_misc
+         - furnace_food
+         - furnace_blocks
+         - furnace_misc
+         - blast_furnace_blocks
+         - blast_furnace_misc
+         - smoker_food
+         - stonecutter
+         - smithing
+         - campfire
+         hasIngredients: bool
+         ingredientCount: hasIngredients ?
+            if true: varint
+            default: void
+         ingredients: hasIngredients ?
+            if true: ["registryEntryHolderSet", {
                "base": { name: "name", type: "string" },
                "otherwise": { name: "ids", type: "varint" }
             }]
-         flags: ["bitflags", {
-            "type": "u8",
-            "flags": ["notification", "highlight"]
-         }]
+            default: void
+         flags: u8
       replace: bool
    # MC: ClientboundRecipeBookRemovePacket
    packet_recipe_book_remove:
@@ -2623,16 +2623,18 @@
       # ]]
       flags: u8
    # MC: ClientboundUpdateRecipesPacket
-   # TODO: update packet
    packet_declare_recipes:
-      recipes: []varint
-         name: string
+      propertySetCount: varint
+      propertySets: []varint
+         propertySetId: string
+         itemCount: varint
          items: varint[]varint
-      stoneCutterRecipes: []varint
-         input: ["registryEntryHolderSet", {
-                  "base": { name: "name", type: "string" },
-                  "otherwise": { name: "ids", type: "varint" }
-               }]
+      stonecutterRecipeCount: varint
+      stonecutterRecipes: []varint
+         ingredients: ["registryEntryHolderSet", {
+            "base": { name: "name", type: "string" },
+            "otherwise": { name: "ids", type: "varint" }
+         }]
          slotDisplay: SlotDisplay
 
    # MC: ClientboundUpdateTagsPacket
@@ -3076,11 +3078,13 @@
    # MC: ServerboundLockDifficultyPacket
    packet_lock_difficulty:
       locked: bool
+   # MC: 
+   MovementFlags: ["bitfield", [
+      { "name": "onGround", "size": 1, "signed": false },               # 0x01
+      { "name": "hasHorizontalCollision", "size": 1, "signed": false }, # 0x02
+      { "name": "unused", "size": 6, "signed": false }                  # Remaining bits
+   ]]
 
-   MovementFlags: ["bitflags", {
-      "type": "u8",
-      "flags": ["onGround", "hasHorizontalCollision"]
-   }]
    # MC: ServerboundMovePlayerPacket.Pos
    packet_position:
       x: f64
@@ -3141,11 +3145,16 @@
       jumpBoost: varint
    # MC: ServerboundPlayerInputPacket
    packet_steer_vehicle:
-      ## client/net/minecraft/world/entity/player/Input.java
-      inputs: ["bitflags", {
-         "type": "u8",
-         "flags": ["forward", "backward", "left", "right", "jump", "sneak", "sprint"]
-      }]
+      inputs: ["bitfield", [
+         { "name": "forward", "size": 1, "signed": false },
+         { "name": "backward", "size": 1, "signed": false },
+         { "name": "left", "size": 1, "signed": false },
+         { "name": "right", "size": 1, "signed": false },
+         { "name": "jump", "size": 1, "signed": false },
+         { "name": "shift", "size": 1, "signed": false },
+         { "name": "sprint", "size": 1, "signed": false },
+         { "name": "unused", "size": 1, "signed": false }
+      ]]
    # MC: ServerboundPongPacket
    packet_pong:
       id: i32


### PR DESCRIPTION
This is my first PR for this repository, and I wanted to help out with the update to 1.21.3, so I completed the tasks listed in the PR for minecraft-data https://github.com/PrismarineJS/minecraft-data/pull/936.  
I obtained most of the data from [wiki.vg](https://wiki.vg/Pre-release_protocol), and some from [Extracted Minecraft Data](https://github.com/extremeheat/extracted_minecraft_data/tree/client1.21.3).

The updates from the PR task list include:
- packet_recipe_book_add
- packet_craft_recipe_response
- packet_declare_recipes

And a few other updates due to tests not passing (following the changes in the wiki):
- MovementFlags
- packet_steer_vehicle
- packet_position

A couple of other notes:
- I also switched to the bitfields version of PositionUpdateRelatives to get the tests to pass. 
- I did not update anything in packet_set_cooldown, because the wiki did not show any changes to the protocol. 

If there is more work to be done, I would be happy to help out, but would need some guidance for where to contribute. 